### PR TITLE
Precompute Blob CID, fixes #21

### DIFF
--- a/blob.go
+++ b/blob.go
@@ -5,67 +5,62 @@ import (
 
 	cid "github.com/ipfs/go-cid"
 	node "github.com/ipfs/go-ipld-format"
-	mh "github.com/multiformats/go-multihash"
 )
 
-type Blob []byte
-
-func (b Blob) Cid() cid.Cid {
-	c, _ := cid.Prefix{
-		MhType:   mh.SHA1,
-		MhLength: -1,
-		Codec:    cid.GitRaw,
-		Version:  1,
-	}.Sum([]byte(b))
-	return c
+type Blob struct {
+	rawData []byte
+	cid     cid.Cid
 }
 
-func (b Blob) Copy() node.Node {
-	out := make([]byte, len(b))
-	copy(out, b)
-	return Blob(out)
+func (b *Blob) Cid() cid.Cid {
+	return b.cid
 }
 
-func (b Blob) Links() []*node.Link {
+func (b *Blob) Copy() node.Node {
+	nb := *b
+	return &nb
+}
+
+func (b *Blob) Links() []*node.Link {
 	return nil
 }
 
-func (b Blob) Resolve(_ []string) (interface{}, []string, error) {
+func (b *Blob) Resolve(_ []string) (interface{}, []string, error) {
 	return nil, nil, errors.New("no such link")
 }
 
-func (b Blob) ResolveLink(_ []string) (*node.Link, []string, error) {
+func (b *Blob) ResolveLink(_ []string) (*node.Link, []string, error) {
 	return nil, nil, errors.New("no such link")
 }
 
-func (b Blob) Loggable() map[string]interface{} {
+func (b *Blob) Loggable() map[string]interface{} {
 	return map[string]interface{}{
 		"type": "git_blob",
 	}
 }
 
-func (b Blob) RawData() []byte {
-	return []byte(b)
+func (b *Blob) RawData() []byte {
+	return []byte(b.rawData)
 }
 
-func (b Blob) Size() (uint64, error) {
-	return uint64(len(b)), nil
+func (b *Blob) Size() (uint64, error) {
+	return uint64(len(b.rawData)), nil
 }
 
-func (b Blob) Stat() (*node.NodeStat, error) {
+func (b *Blob) Stat() (*node.NodeStat, error) {
 	return &node.NodeStat{}, nil
 }
 
-func (b Blob) String() string {
+func (b *Blob) String() string {
 	return "[git blob]"
 }
 
-func (b Blob) Tree(p string, depth int) []string {
+func (b *Blob) Tree(p string, depth int) []string {
 	return nil
 }
 
-func (b Blob) GitSha() []byte {
+func (b *Blob) GitSha() []byte {
 	return cidToSha(b.Cid())
 }
 
-var _ node.Node = (Blob)(nil)
+var _ node.Node = (*Blob)(nil)

--- a/git.go
+++ b/git.go
@@ -67,7 +67,7 @@ func ParseObject(r io.Reader) (node.Node, error) {
 	}
 }
 
-func ReadBlob(rd *bufio.Reader) (Blob, error) {
+func ReadBlob(rd *bufio.Reader) (*Blob, error) {
 	size, err := rd.ReadString(0)
 	if err != nil {
 		return nil, err
@@ -90,7 +90,11 @@ func ReadBlob(rd *bufio.Reader) (Blob, error) {
 		return nil, fmt.Errorf("blob size was not accurate")
 	}
 
-	return Blob(buf.Bytes()), nil
+	out := &Blob{}
+	out.rawData = buf.Bytes()
+	out.cid = hashObject(out.RawData())
+
+	return out, nil
 }
 
 func ReadCommit(rd *bufio.Reader) (*Commit, error) {

--- a/git_test.go
+++ b/git_test.go
@@ -152,7 +152,7 @@ func TestArchiveObjectParse(t *testing.T) {
 func testNode(t *testing.T, nd node.Node) error {
 	switch nd.String() {
 	case "[git blob]":
-		blob, ok := nd.(Blob)
+		blob, ok := nd.(*Blob)
 		if !ok {
 			t.Fatalf("Blob is not a blob")
 		}


### PR DESCRIPTION
The Blob type is changed to a struct with rawdata and cid members so Blob CIDs can be precomputed in `ReadBlob`.

Let me know if there are any changes that need to be made, feedback is welcome.