### PR TITLE
Cache RawData for Commit, Tag, & Tree, fixes #6

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -3,24 +3,27 @@ package ipldgit
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"sync"
 
-	"errors"
 	cid "github.com/ipfs/go-cid"
 	node "github.com/ipfs/go-ipld-format"
 )
 
 type Tree struct {
-	entries map[string]*TreeEntry
-	size    int
-	order   []string
-	cid     cid.Cid
+	entries     map[string]*TreeEntry
+	size        int
+	order       []string
+	cid         cid.Cid
+	rawData     []byte
+	rawDataOnce sync.Once
 }
 
 type TreeEntry struct {
 	name string
-	Mode string   `json:"mode"`
+	Mode string  `json:"mode"`
 	Hash cid.Cid `json:"hash"`
 }
 
@@ -95,13 +98,17 @@ func (t *Tree) Loggable() map[string]interface{} {
 }
 
 func (t *Tree) RawData() []byte {
-	buf := new(bytes.Buffer)
+	t.rawDataOnce.Do(func() {
+		buf := new(bytes.Buffer)
 
-	fmt.Fprintf(buf, "tree %d\x00", t.size)
-	for _, s := range t.order {
-		t.entries[s].WriteTo(buf)
-	}
-	return buf.Bytes()
+		fmt.Fprintf(buf, "tree %d\x00", t.size)
+		for _, s := range t.order {
+			t.entries[s].WriteTo(buf)
+		}
+		t.rawData = buf.Bytes()
+	})
+
+	return t.rawData
 }
 
 func (t *Tree) Resolve(p []string) (interface{}, []string, error) {


### PR DESCRIPTION
A `rawdata []byte` member is added to each type. It is computed on the first call to `RawData()`.
Also noticed a few odd indentations and fixed them.

Let me know if there are any changes that need to be made, feedback is welcome.