### PR TITLE
Use rawdata length for size, fixes #7

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -231,7 +231,7 @@ func (c *Commit) ResolveLink(path []string) (*node.Link, []string, error) {
 }
 
 func (c *Commit) Size() (uint64, error) {
-	return 42, nil // close enough
+	return uint64(len(c.RawData())), nil
 }
 
 func (c *Commit) Stat() (*node.NodeStat, error) {

--- a/tag.go
+++ b/tag.go
@@ -102,7 +102,7 @@ func (t *Tag) ResolveLink(path []string) (*node.Link, []string, error) {
 }
 
 func (t *Tag) Size() (uint64, error) {
-	return 42, nil // close enough
+	return uint64(len(t.RawData())), nil
 }
 
 func (t *Tag) Stat() (*node.NodeStat, error) {

--- a/tree.go
+++ b/tree.go
@@ -146,8 +146,7 @@ func (t Tree) ResolveLink(path []string) (*node.Link, []string, error) {
 }
 
 func (t *Tree) Size() (uint64, error) {
-	fmt.Println("size isnt implemented")
-	return 13, nil // trees are probably smaller than commits, so 13 seems like a good number
+	return uint64(len(t.RawData())), nil
 }
 
 func (t *Tree) Stat() (*node.NodeStat, error) {


### PR DESCRIPTION
This fixes #7. I'm assuming here that calling `Size()` means `RawData()` will probably be called later. Let me know if any changes are needed.